### PR TITLE
fix: UILD-74: lccn normalize query no hyphen zero backfill position

### DIFF
--- a/src/test/__tests__/common/helpers/validations.helper.test.ts
+++ b/src/test/__tests__/common/helpers/validations.helper.test.ts
@@ -15,6 +15,8 @@ describe('validations.helper', () => {
 
     test('backfills with zeroes', () => {
       expect(normalizeLccn('1234-567')).toEqual('1234000567');
+      expect(normalizeLccn('1234567')).toEqual('1234000567');
+      expect(normalizeLccn('1234')).toEqual('1234000000');
     });
   });
 


### PR DESCRIPTION
https://issues.folio.org/browse/UILD-74